### PR TITLE
Added GenericDeviceService and REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,15 @@ The main difference between both is that the second generation allows bidirectio
   
   ```http://127.0.0.1:8181/rollingshutter/v2/getposition/22594```
 
-As it can be seen, actions are send using the device ID. 
+- Get current value of any registered device:
+  
+  ```http://127.0.0.1:8181/generic/3146```
+  
+- set current value of any registered device:
+  
+  ```http://127.0.0.1:8181/generic/3146/true```
+
+As it can be seen, actions are sent using the device ID. 
 It is mandatory to specify the version of the roller shutter (v1 or v2). 
 
 ## Authors

--- a/controllers/RestAPIController.js
+++ b/controllers/RestAPIController.js
@@ -11,6 +11,7 @@
 const express = require('express');
 const UnidirectionalRollingShutterService = require('../services/UnidirectionalRollingShutterService');
 const BidirectionalRollingShutterService = require('../services/BidirectionalRollingShutterService');
+const GenericDeviceService = require('../services/GenericDeviceService');
 const valueMapping = new Map([['up', 1], ['down', 2], ['stop', 0]]);
 
 class RestAPIController {
@@ -24,6 +25,7 @@ class RestAPIController {
 
         this.uniDirectionalRSService = new UnidirectionalRollingShutterService(config);
         this.biDirectionalRSService = new BidirectionalRollingShutterService(config);
+        this.genericDeviceService = new GenericDeviceService(config);
         this.port = config.restAPIConfig.port;
         
         this.startRestAPI();
@@ -88,6 +90,33 @@ class RestAPIController {
             var log;
             if(result) {
                 var log = 'Rolling Shutter SET POSITION command received for device: ' + deviceID + ' (new position => ' + position + ')';
+            } else {
+                log = 'Oups. Somesthing went wrong!';
+            }
+            console.debug(log);
+            return res.send(log);
+        });
+
+        app.get('/generic/:deviceID', (req, res) => {
+            var deviceID = parseInt(req.params.deviceID);
+            var result = this.genericDeviceService.getValue(deviceID);
+            var log;
+            if(result) {
+                var log = 'Generic device: ' + deviceID + ' (set value => ' + result + ')';
+            } else {
+                log = 'Oups. Somesthing went wrong!';
+            }
+            console.debug(log);
+            return res.send(result.toString());
+        });
+
+        app.get('/generic/:deviceID/:value', (req, res) => {
+            var deviceID = parseInt(req.params.deviceID);
+            var value = req.params.value;
+            var result = this.genericDeviceService.setValue(deviceID, value);
+            var log;
+            if(result) {
+                var log = 'Generic device: ' + deviceID + ' (set value => ' + value + ')';
             } else {
                 log = 'Oups. Somesthing went wrong!';
             }

--- a/services/GenericDeviceService.js
+++ b/services/GenericDeviceService.js
@@ -1,0 +1,83 @@
+/**
+ * Generic Device Services
+ *
+ * Manages Generic Devices using Schellenberg API
+ *
+ * @file   GenericDeviceService.js
+ * @author GimpArm
+ * @since  1.0.0
+ */
+
+const SchellenbergAPIConnector = require('./SchellenbergAPIConnector');
+
+class GenericDeviceService {
+
+    constructor(config) {
+
+        this.api = new SchellenbergAPIConnector(config).getInstance();
+    }
+
+    /**
+     * Sends a value to the device
+     *
+     * @param {number} deviceID the device's ID to operate
+     * @param {string} value to set on for the device
+     * @returns {boolean} true on success, false otherwise
+     */
+    setValue(deviceID, value) {
+        if (!this.isValidDevice(deviceID)) {
+            console.error('Received deviceID <' + deviceID + '> is not valid! Command cancelled.');
+            return '';
+        }
+
+        var sendVal = this.convertValue(value);
+        return this.api.setDeviceValue(deviceID, sendVal);
+    }
+
+    /**
+     * Gets the current roller shutter position
+     *
+     * @param {number} deviceID the device's ID to operate
+     * @returns {number} current value
+     */
+    getValue(deviceID) {
+        if (!this.isValidDevice(deviceID)) {
+            console.error('Received deviceID <' + deviceID + '> is not valid! Command cancelled.');
+            return '';
+        }
+
+        return this.api.getDeviceValue(deviceID);
+    }
+
+    /**
+     * Checks if the device is valid
+     *
+     * @param {number} deviceID the device's ID to operate
+     * @returns {boolean} true if the device is valid, false otherwise
+     */
+    isValidDevice(deviceID) {
+        return this.api.smartSocket.handler.dataStorage.deviceMap.has(deviceID);
+    }
+
+    /**
+     * Converts a string value to the proper JavaScript type so it will be serialized correctly
+     *
+     * @param {string} value to convert to the proper type
+     * @returns {any} value as int, float, boolean, or string
+     */
+    convertValue(value){
+        if (!isNaN(value)) {
+            if (value.indexOf('.' != -1)) {
+                return parseFloat(value);
+            }
+            return parseInt(value);
+        } else if (value.toLowerCase() == 'true') {
+            return true;
+        } else if (value.toLowerCase() == 'false') {
+            return false;
+        }
+        return value;
+    }
+}
+
+module.exports = GenericDeviceService;


### PR DESCRIPTION
Added GenericDeviceService for controlling any device, not just a Rolling Shutter. I tested this with generic Zigbee switches and they can be controlled and their status can be retrieved using the same ShellerbergApi from LoPablo.